### PR TITLE
feat: enable seamless moody snow transition

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md (for Android)
 
 ### Validation　(required before push)
-Run `./gradlew assembleDebug`.
+Run `./gradlew --console=plain assembleDebug`.
 
 ## Linting
 - You may run `./gradlew lint` before submitting changes.

--- a/app/src/main/java/com/example/uigallary01/GalleryScreen.kt
+++ b/app/src/main/java/com/example/uigallary01/GalleryScreen.kt
@@ -1,5 +1,6 @@
 package com.example.uigallary01
 
+import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -12,6 +13,10 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -19,6 +24,10 @@ import com.example.uigallary01.ui.theme.UiGallary01Theme
 
 @Composable
 fun GalleryScreen(modifier: Modifier = Modifier) {
+    // Moody Snow をフルスクリーン表示するかどうかを保持
+    var isMoodySnowExpanded by rememberSaveable { mutableStateOf(false) }
+    val moodySnowState = rememberMoodySnowBackgroundState()
+
     // ギャラリーに表示する要素を定義
     val galleryItems = listOf(
         GalleryItem(
@@ -27,17 +36,32 @@ fun GalleryScreen(modifier: Modifier = Modifier) {
         ),
         GalleryItem(
             title = "Moody Snow Background",
-            content = { MoodySnowBackgroundItem() }
+            content = { MoodySnowBackgroundItem(state = moodySnowState) },
+            onClick = { isMoodySnowExpanded = true }
         )
     )
 
-    LazyColumn(
-        modifier = modifier.fillMaxSize(),
-        contentPadding = PaddingValues(16.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp)
-    ) {
-        items(galleryItems) { item ->
-            item.ListItem()
+    Crossfade(targetState = isMoodySnowExpanded, label = "galleryContent") { expanded ->
+        if (expanded) {
+            MoodySnowBackgroundFullScreen(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .then(modifier),
+                state = moodySnowState,
+                onDismiss = { isMoodySnowExpanded = false }
+            )
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .then(modifier),
+                contentPadding = PaddingValues(16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                items(galleryItems) { item ->
+                    item.ListItem()
+                }
+            }
         }
     }
 }
@@ -53,13 +77,17 @@ private fun GalleryScreenPreview() {
 // ギャラリーに表示する要素の定義
 private data class GalleryItem(
     val title: String,
-    val content: @Composable () -> Unit
+    val content: @Composable () -> Unit,
+    val onClick: (() -> Unit)? = null,
 )
 
 // データクラス自身が描画手段を提供できるように拡張関数化
 @Composable
-private fun GalleryItem.ListItem(modifier: Modifier = Modifier) {
-    Card(modifier = modifier.fillMaxWidth()) {
+private fun GalleryItem.ListItem(
+    modifier: Modifier = Modifier,
+    onClick: (() -> Unit)? = this.onClick,
+) {
+    val cardContent: @Composable () -> Unit = {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
@@ -69,6 +97,16 @@ private fun GalleryItem.ListItem(modifier: Modifier = Modifier) {
             // ギャラリー要素のタイトルを表示
             Text(text = title, style = MaterialTheme.typography.titleMedium)
             content()
+        }
+    }
+
+    if (onClick != null) {
+        Card(onClick = onClick, modifier = modifier.fillMaxWidth()) {
+            cardContent()
+        }
+    } else {
+        Card(modifier = modifier.fillMaxWidth()) {
+            cardContent()
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a crossfade transition that expands the Moody Snow item into a full-screen experience
- extract reusable Moody Snow background state and surface helpers to reuse animation between list and expanded views

## Testing
- ./gradlew --console=plain assembleDebug

------
https://chatgpt.com/codex/tasks/task_e_68db42d9fa98832f86e8af2254a54dfe