### PR TITLE
feat: animate Moody Snow background expansion

### DIFF
--- a/app/src/main/java/com/example/uigallary01/GalleryScreen.kt
+++ b/app/src/main/java/com/example/uigallary01/GalleryScreen.kt
@@ -1,6 +1,5 @@
 package com.example.uigallary01
 
-import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -13,10 +12,6 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -24,8 +19,6 @@ import com.example.uigallary01.ui.theme.UiGallary01Theme
 
 @Composable
 fun GalleryScreen(modifier: Modifier = Modifier) {
-    // Moody Snow をフルスクリーン表示するかどうかを保持
-    var isMoodySnowExpanded by rememberSaveable { mutableStateOf(false) }
     val moodySnowState = rememberMoodySnowBackgroundState()
 
     // ギャラリーに表示する要素を定義
@@ -37,31 +30,18 @@ fun GalleryScreen(modifier: Modifier = Modifier) {
         GalleryItem(
             title = "Moody Snow Background",
             content = { MoodySnowBackgroundItem(state = moodySnowState) },
-            onClick = { isMoodySnowExpanded = true }
         )
     )
 
-    Crossfade(targetState = isMoodySnowExpanded, label = "galleryContent") { expanded ->
-        if (expanded) {
-            MoodySnowBackgroundFullScreen(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .then(modifier),
-                state = moodySnowState,
-                onDismiss = { isMoodySnowExpanded = false }
-            )
-        } else {
-            LazyColumn(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .then(modifier),
-                contentPadding = PaddingValues(16.dp),
-                verticalArrangement = Arrangement.spacedBy(12.dp)
-            ) {
-                items(galleryItems) { item ->
-                    item.ListItem()
-                }
-            }
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .then(modifier),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        items(galleryItems) { item ->
+            item.ListItem()
         }
     }
 }

--- a/app/src/main/java/com/example/uigallary01/GalleryScreen.kt
+++ b/app/src/main/java/com/example/uigallary01/GalleryScreen.kt
@@ -58,14 +58,12 @@ private fun GalleryScreenPreview() {
 private data class GalleryItem(
     val title: String,
     val content: @Composable () -> Unit,
-    val onClick: (() -> Unit)? = null,
 )
 
 // データクラス自身が描画手段を提供できるように拡張関数化
 @Composable
 private fun GalleryItem.ListItem(
     modifier: Modifier = Modifier,
-    onClick: (() -> Unit)? = this.onClick,
 ) {
     val cardContent: @Composable () -> Unit = {
         Column(
@@ -80,13 +78,7 @@ private fun GalleryItem.ListItem(
         }
     }
 
-    if (onClick != null) {
-        Card(onClick = onClick, modifier = modifier.fillMaxWidth()) {
-            cardContent()
-        }
-    } else {
-        Card(modifier = modifier.fillMaxWidth()) {
-            cardContent()
-        }
+    Card(modifier = modifier.fillMaxWidth()) {
+        cardContent()
     }
 }

--- a/app/src/main/java/com/example/uigallary01/MoodySnowBackgroundItem.kt
+++ b/app/src/main/java/com/example/uigallary01/MoodySnowBackgroundItem.kt
@@ -1,6 +1,7 @@
 package com.example.uigallary01
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.RepeatMode
@@ -68,7 +69,12 @@ fun MoodySnowBackgroundItem(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(horizontal = 24.dp, vertical = 32.dp),
-            verticalArrangement = Arrangement.SpaceBetween,
+            verticalArrangement = if (isExpanded) {
+                Arrangement.SpaceBetween
+            } else {
+                Arrangement.Bottom
+            },
+            showMessage = isExpanded,
         )
     }
 }
@@ -104,7 +110,8 @@ fun MoodySnowBackgroundFullScreen(
             }
             MoodySnowCopy(
                 modifier = Modifier.align(Alignment.BottomStart),
-                verticalArrangement = Arrangement.spacedBy(20.dp)
+                verticalArrangement = Arrangement.spacedBy(20.dp),
+                showMessage = true,
             )
         }
     }
@@ -173,6 +180,7 @@ private fun MoodySnowBackgroundSurface(
 private fun MoodySnowCopy(
     modifier: Modifier,
     verticalArrangement: Arrangement.Vertical,
+    showMessage: Boolean,
 ) {
     Column(
         modifier = modifier,
@@ -189,12 +197,15 @@ private fun MoodySnowCopy(
                 )
             )
         )
-        Text(
-            text = "静かに舞い落ちる雪に包まれた夜の空気を想像してください。",
-            style = MaterialTheme.typography.bodyMedium.copy(
-                color = Color(0xFFD9E4FF)
+        // 拡大時のみ説明文を表示して、閉じているときはタイトルだけにする
+        AnimatedVisibility(visible = showMessage) {
+            Text(
+                text = "静かに舞い落ちる雪に包まれた夜の空気を想像してください。",
+                style = MaterialTheme.typography.bodyMedium.copy(
+                    color = Color(0xFFD9E4FF)
+                )
             )
-        )
+        }
     }
 }
 

--- a/app/src/main/java/com/example/uigallary01/MoodySnowBackgroundItem.kt
+++ b/app/src/main/java/com/example/uigallary01/MoodySnowBackgroundItem.kt
@@ -2,11 +2,13 @@ package com.example.uigallary01
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -23,7 +25,11 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
@@ -43,11 +49,19 @@ fun MoodySnowBackgroundItem(
     modifier: Modifier = Modifier,
     state: MoodySnowBackgroundState = rememberMoodySnowBackgroundState(),
 ) {
+    // タップごとにサイズを切り替える状態を保持
+    var isExpanded by rememberSaveable { mutableStateOf(false) }
+    val animatedHeight by animateDpAsState(
+        targetValue = if (isExpanded) 360.dp else 220.dp,
+        label = "snowItemHeight"
+    )
+
     MoodySnowBackgroundSurface(
         modifier = modifier
             .fillMaxWidth()
-            .height(220.dp)
-            .clip(RoundedCornerShape(24.dp)),
+            .height(animatedHeight)
+            .clip(RoundedCornerShape(24.dp))
+            .clickable { isExpanded = !isExpanded },
         state = state,
     ) {
         MoodySnowCopy(

--- a/app/src/main/java/com/example/uigallary01/MoodySnowBackgroundItem.kt
+++ b/app/src/main/java/com/example/uigallary01/MoodySnowBackgroundItem.kt
@@ -57,7 +57,7 @@ fun MoodySnowBackgroundItem(
     // タップごとにサイズを切り替える状態を保持
     var isExpanded by rememberSaveable { mutableStateOf(false) }
     val animatedHeight by animateDpAsState(
-        targetValue = if (isExpanded) 360.dp else 220.dp,
+        targetValue = if (isExpanded) 360.dp else 160.dp,
         label = "snowItemHeight"
     )
 

--- a/app/src/main/java/com/example/uigallary01/MoodySnowBackgroundItem.kt
+++ b/app/src/main/java/com/example/uigallary01/MoodySnowBackgroundItem.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -39,6 +40,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.lerp
 import kotlin.math.PI
@@ -69,12 +71,9 @@ fun MoodySnowBackgroundItem(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(horizontal = 24.dp, vertical = 32.dp),
-            verticalArrangement = if (isExpanded) {
-                Arrangement.SpaceBetween
-            } else {
-                Arrangement.Bottom
-            },
+            verticalArrangement = Arrangement.Bottom,
             showMessage = isExpanded,
+            messageSpacing = 16.dp,
         )
     }
 }
@@ -181,12 +180,25 @@ private fun MoodySnowCopy(
     modifier: Modifier,
     verticalArrangement: Arrangement.Vertical,
     showMessage: Boolean,
+    messageSpacing: Dp = 0.dp,
 ) {
     Column(
         modifier = modifier,
         verticalArrangement = verticalArrangement,
         horizontalAlignment = Alignment.Start
     ) {
+        // タイトルの位置を保ったまま説明文を加える
+        AnimatedVisibility(visible = showMessage) {
+            Column {
+                Text(
+                    text = "静かに舞い落ちる雪に包まれた夜の空気を想像してください。",
+                    style = MaterialTheme.typography.bodyMedium.copy(
+                        color = Color(0xFFD9E4FF)
+                    )
+                )
+                Spacer(modifier = Modifier.height(messageSpacing))
+            }
+        }
         Text(
             text = "Moody Snowfall",
             style = MaterialTheme.typography.headlineSmall.copy(
@@ -197,15 +209,6 @@ private fun MoodySnowCopy(
                 )
             )
         )
-        // 拡大時のみ説明文を表示して、閉じているときはタイトルだけにする
-        AnimatedVisibility(visible = showMessage) {
-            Text(
-                text = "静かに舞い落ちる雪に包まれた夜の空気を想像してください。",
-                style = MaterialTheme.typography.bodyMedium.copy(
-                    color = Color(0xFFD9E4FF)
-                )
-            )
-        }
     }
 }
 

--- a/app/src/main/java/com/example/uigallary01/MoodySnowBackgroundItem.kt
+++ b/app/src/main/java/com/example/uigallary01/MoodySnowBackgroundItem.kt
@@ -1,6 +1,5 @@
 package com.example.uigallary01
 
-import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.animateDpAsState
@@ -13,7 +12,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -23,7 +21,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.Stable
@@ -34,6 +31,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
@@ -41,7 +39,6 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.graphics.drawscope.DrawScope
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.lerp
@@ -77,44 +74,6 @@ fun MoodySnowBackgroundItem(
             showMessage = isExpanded,
             messageSpacing = 16.dp,
         )
-    }
-}
-
-@Composable
-fun MoodySnowBackgroundFullScreen(
-    modifier: Modifier = Modifier,
-    state: MoodySnowBackgroundState,
-    onDismiss: () -> Unit,
-) {
-    // システムの戻る操作でも一覧へ戻れるようにする
-    BackHandler(onBack = onDismiss)
-
-    MoodySnowBackgroundSurface(
-        modifier = modifier,
-        state = state,
-    ) {
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(horizontal = 32.dp, vertical = 48.dp)
-        ) {
-            TextButton(
-                onClick = onDismiss,
-                modifier = Modifier.align(Alignment.TopEnd)
-            ) {
-                Text(
-                    text = "閉じる",
-                    style = MaterialTheme.typography.titleSmall.copy(
-                        color = Color(0xFFEBF7FF)
-                    )
-                )
-            }
-            MoodySnowCopy(
-                modifier = Modifier.align(Alignment.BottomStart),
-                verticalArrangement = Arrangement.spacedBy(20.dp),
-                showMessage = true,
-            )
-        }
     }
 }
 
@@ -162,7 +121,7 @@ class MoodySnowBackgroundState internal constructor(
 private fun MoodySnowBackgroundSurface(
     modifier: Modifier,
     state: MoodySnowBackgroundState,
-    overlay: @Composable BoxScope.() -> Unit,
+    overlay: @Composable () -> Unit,
 ) {
     Box(modifier = modifier) {
         Canvas(modifier = Modifier.matchParentSize()) {


### PR DESCRIPTION
## Summary
- animate the MoodySnowBackgroundItem height so it expands and collapses on tap
- simplify GalleryScreen to keep the list layout while the item handles its own interaction

## Testing
- ./gradlew --console=plain assembleDebug

------
https://chatgpt.com/codex/tasks/task_e_68db4c41a91c832fa18728296bddc4fe