### PR TITLE
feat: Add scramble text gallery item

### DIFF
--- a/app/src/main/java/com/example/uigallary01/DigitalRainBackgroundItem.kt
+++ b/app/src/main/java/com/example/uigallary01/DigitalRainBackgroundItem.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -92,24 +91,23 @@ private fun DigitalRainCopy(
         // タイトルを所定の位置に保ったまま説明文を加える
         AnimatedVisibility(visible = showMessage) {
             Column {
-                Text(
+                ScrambleText(
                     text = "その信号の一つひとつを感じ\nあたらしい世界へ踏み出す光景を想像して下さい",
-                    style = MaterialTheme.typography.bodyMedium.copy(
-                        color = Color(0xFFB4FFB4)
-                    )
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = Color(0xFFB4FFB4),
                 )
                 Spacer(modifier = Modifier.height(messageSpacing))
             }
         }
-        Text(
+        ScrambleText(
             text = "Digital Rain",
             style = MaterialTheme.typography.headlineSmall.copy(
-                color = Color(0xFF90FF90),
                 shadow = Shadow(
                     color = Color.Black.copy(alpha = 0.65f),
                     blurRadius = 12f,
                 )
-            )
+            ),
+            color = Color(0xFF90FF90),
         )
     }
 }

--- a/app/src/main/java/com/example/uigallary01/GalleryScreen.kt
+++ b/app/src/main/java/com/example/uigallary01/GalleryScreen.kt
@@ -28,6 +28,10 @@ fun GalleryScreen(modifier: Modifier = Modifier) {
             content = { HelloWorldDialogItem() }
         ),
         GalleryItem(
+            title = "Scramble Text",
+            content = { ScrambleTextItem() }
+        ),
+        GalleryItem(
             title = "Digital Rain Background",
             content = { DigitalRainBackgroundItem() }
         ),

--- a/app/src/main/java/com/example/uigallary01/MoodySnowBackgroundItem.kt
+++ b/app/src/main/java/com/example/uigallary01/MoodySnowBackgroundItem.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.Stable
@@ -152,24 +151,23 @@ private fun MoodySnowCopy(
         // タイトルの位置を保ったまま説明文を加える
         AnimatedVisibility(visible = showMessage) {
             Column {
-                Text(
+                ScrambleText(
                     text = "静寂に包まれた雪夜\nそこに佇むあなたは何を感じますか",
-                    style = MaterialTheme.typography.bodyMedium.copy(
-                        color = Color(0xFFD9E4FF)
-                    )
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = Color(0xFFD9E4FF),
                 )
                 Spacer(modifier = Modifier.height(messageSpacing))
             }
         }
-        Text(
+        ScrambleText(
             text = "Moody Snowfall",
             style = MaterialTheme.typography.headlineSmall.copy(
-                color = Color(0xFFEBF7FF),
                 shadow = Shadow(
                     color = Color.Black.copy(alpha = 0.6f),
                     blurRadius = 12f,
                 )
-            )
+            ),
+            color = Color(0xFFEBF7FF),
         )
     }
 }

--- a/app/src/main/java/com/example/uigallary01/ScrambleText.kt
+++ b/app/src/main/java/com/example/uigallary01/ScrambleText.kt
@@ -1,0 +1,112 @@
+package com.example.uigallary01
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import kotlinx.coroutines.delay
+import kotlin.random.Random
+
+@Composable
+fun ScrambleText(
+    text: String,
+    modifier: Modifier = Modifier,
+    playKey: Any = text,
+    scrambleSeed: Int = playKey.hashCode(),
+    style: TextStyle = MaterialTheme.typography.bodyLarge,
+    color: Color = MaterialTheme.colorScheme.onSurface,
+    glyphs: List<Char> = ScrambleTextDefaults.Glyphs,
+    frameCount: Int = ScrambleTextDefaults.FrameCount,
+    frameIntervalMillis: Long = ScrambleTextDefaults.FrameIntervalMillis,
+    stableCharPredicate: (Char) -> Boolean = ScrambleTextDefaults.StableCharPredicate,
+) {
+    // 利用側で不正な値が渡されないように契約を明示
+    require(frameCount > 1) { "frameCount must be greater than 1." }
+    require(frameIntervalMillis >= 0L) { "frameIntervalMillis must be non-negative." }
+    require(glyphs.isNotEmpty()) { "glyphs must not be empty." }
+
+    var displayText by remember(playKey, text) { mutableStateOf(text) }
+
+    LaunchedEffect(playKey, text, frameCount, frameIntervalMillis, scrambleSeed, glyphs, stableCharPredicate) {
+        val targetText = text
+        if (targetText.isEmpty()) {
+            displayText = targetText
+            return@LaunchedEffect
+        }
+        val random = Random(scrambleSeed)
+        for (frameIndex in 0 until frameCount - 1) {
+            val progress = frameIndex.toScrambleProgress(totalFrames = frameCount)
+            displayText = targetText.scrambledCopy(
+                progress = progress,
+                random = random,
+                glyphs = glyphs,
+                stableCharPredicate = stableCharPredicate,
+            )
+            if (frameIntervalMillis > 0L) {
+                delay(frameIntervalMillis)
+            }
+        }
+        displayText = targetText
+    }
+
+    Text(
+        text = displayText,
+        modifier = modifier,
+        style = style,
+        color = color,
+    )
+}
+
+object ScrambleTextDefaults {
+    // スクランブルに使用する文字一覧
+    val Glyphs: List<Char> = buildList {
+        addAll('A'..'Z')
+        addAll('a'..'z')
+        addAll('0'..'9')
+        addAll(listOf('-', '+', '*', '#', '%', '=', '@'))
+    }
+
+    // アニメーションの総フレーム数
+    const val FrameCount: Int = 28
+
+    // 各フレーム間の待機時間
+    const val FrameIntervalMillis: Long = 40L
+
+    // スクランブル中でも固定表示したい文字の判定
+    val StableCharPredicate: (Char) -> Boolean = { character ->
+        character.isWhitespace() || !character.isLetterOrDigit()
+    }
+}
+
+// 表示フレーム数に対して進捗率を算出する拡張関数
+private fun Int.toScrambleProgress(totalFrames: Int): Float {
+    return (this.toFloat() / (totalFrames - 1)).coerceIn(0f, 1f)
+}
+
+// スクランブル用のテキストを生成する拡張関数
+private fun String.scrambledCopy(
+    progress: Float,
+    random: Random,
+    glyphs: List<Char>,
+    stableCharPredicate: (Char) -> Boolean,
+): String {
+    if (isEmpty() || progress >= 1f) return this
+    val revealCount = (length * progress).toInt().coerceIn(0, length)
+    val builder = StringBuilder(length)
+    forEachIndexed { index, character ->
+        val resolved = when {
+            index < revealCount -> character
+            stableCharPredicate(character) -> character
+            else -> glyphs.random(random)
+        }
+        builder.append(resolved)
+    }
+    return builder.toString()
+}

--- a/app/src/main/java/com/example/uigallary01/ScrambleText.kt
+++ b/app/src/main/java/com/example/uigallary01/ScrambleText.kt
@@ -161,9 +161,23 @@ private fun String.scrambledCopy(
 // 元のテキストから行リストを生成する拡張関数
 private fun String.toScrambleLines(): List<String> {
     if (isEmpty()) return emptyList()
-    return split('\n', ignoreCase = false, limit = -1).map { segment ->
-        if (segment.endsWith('\r')) segment.dropLast(1) else segment
+    val lines = mutableListOf<String>()
+    var lineStartIndex = 0
+    for (index in indices) {
+        if (this[index] == '\n') {
+            lines += substring(lineStartIndex, index).trimTrailingCarriageReturn()
+            lineStartIndex = index + 1
+        }
     }
+    if (lineStartIndex <= length) {
+        lines += substring(lineStartIndex, length).trimTrailingCarriageReturn()
+    }
+    return lines
+}
+
+// Windows系の改行で末尾に付く\rのみを除去する拡張関数
+private fun String.trimTrailingCarriageReturn(): String {
+    return if (endsWith('\r')) dropLast(1) else this
 }
 
 // 行リストから複数行テキストへ変換する拡張関数

--- a/app/src/main/java/com/example/uigallary01/ScrambleTextItem.kt
+++ b/app/src/main/java/com/example/uigallary01/ScrambleTextItem.kt
@@ -13,55 +13,24 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.example.uigallary01.ui.theme.UiGallary01Theme
-import kotlinx.coroutines.delay
-import kotlin.random.Random
 
 @Composable
 fun ScrambleTextItem(
     modifier: Modifier = Modifier,
 ) {
-    // スクランブル後に表示したいテキスト行を定義
-    val targetLines = remember {
-        listOf(
-            "Signals weave through the dark.",
-            "Fragments align into a message.",
-            "Embrace the moment decoding you.",
-        )
-    }
-
-    // 現在表示しているテキストの状態を保持
-    var displayLines by remember { mutableStateOf(targetLines) }
+    // ギャラリー表示用の文面を定義
+    val targetLines = ScrambleDemoLines
     var playSeed by rememberSaveable { mutableIntStateOf(0) }
-
-    LaunchedEffect(playSeed) {
-        // 再生トリガーが変わるたびに新しいスクランブルを開始
-        val random = Random(playSeed)
-        repeat(ScrambleFrameCount) { frameIndex ->
-            val progress = frameIndex.toScrambleProgress(totalFrames = ScrambleFrameCount)
-            displayLines = targetLines.map { line ->
-                line.scrambledCopy(
-                    progress = progress,
-                    random = random,
-                )
-            }
-            delay(ScrambleFrameIntervalMillis)
-        }
-        // 最終フレームで確定したテキストを表示
-        displayLines = targetLines
-    }
 
     Column(
         modifier = modifier
@@ -72,10 +41,12 @@ fun ScrambleTextItem(
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
         Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-            // ターゲットのメッセージをスクランブル表示
-            displayLines.forEach { line ->
-                Text(
+            // 再生シードをキーにスクランブル表示を更新
+            targetLines.forEachIndexed { index, line ->
+                ScrambleText(
                     text = line,
+                    playKey = playSeed to index,
+                    scrambleSeed = playSeed * 31 + index,
                     style = MaterialTheme.typography.bodyLarge.copy(fontFamily = FontFamily.Monospace),
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -88,45 +59,11 @@ fun ScrambleTextItem(
     }
 }
 
-// 表示フレーム数に対して進捗率を算出する拡張関数
-private fun Int.toScrambleProgress(totalFrames: Int): Float {
-    require(totalFrames > 1)
-    return (this.toFloat() / (totalFrames - 1)).coerceIn(0f, 1f)
-}
-
-// スクランブル用のテキストを生成する拡張関数
-private fun String.scrambledCopy(
-    progress: Float,
-    random: Random,
-): String {
-    if (isEmpty() || progress >= 1f) return this
-    val revealCount = (length * progress).toInt().coerceIn(0, length)
-    val builder = StringBuilder(length)
-    forEachIndexed { index, character ->
-        val resolved = when {
-            index < revealCount -> character
-            character.isScrambleStable() -> character
-            else -> ScrambleGlyphs.random(random)
-        }
-        builder.append(resolved)
-    }
-    return builder.toString()
-}
-
-// スクランブル中でも変化させない文字かどうかを判定する拡張関数
-private fun Char.isScrambleStable(): Boolean {
-    return isWhitespace() || !isLetterOrDigit()
-}
-
-private val ScrambleGlyphs: List<Char> = buildList {
-    addAll('A'..'Z')
-    addAll('a'..'z')
-    addAll('0'..'9')
-    addAll(listOf('-', '+', '*', '#', '%', '=', '@'))
-}
-
-private const val ScrambleFrameCount: Int = 28
-private const val ScrambleFrameIntervalMillis: Long = 40L
+private val ScrambleDemoLines = listOf(
+    "Signals weave through the dark.",
+    "Fragments align into a message.",
+    "Embrace the moment decoding you.",
+)
 
 @Preview
 @Composable

--- a/app/src/main/java/com/example/uigallary01/ScrambleTextItem.kt
+++ b/app/src/main/java/com/example/uigallary01/ScrambleTextItem.kt
@@ -1,0 +1,141 @@
+package com.example.uigallary01
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.example.uigallary01.ui.theme.UiGallary01Theme
+import kotlinx.coroutines.delay
+import kotlin.random.Random
+
+@Composable
+fun ScrambleTextItem(
+    modifier: Modifier = Modifier,
+) {
+    // スクランブル後に表示したいテキスト行を定義
+    val targetLines = remember {
+        listOf(
+            "Signals weave through the dark.",
+            "Fragments align into a message.",
+            "Embrace the moment decoding you.",
+        )
+    }
+
+    // 現在表示しているテキストの状態を保持
+    var displayLines by remember { mutableStateOf(targetLines) }
+    var playSeed by rememberSaveable { mutableIntStateOf(0) }
+
+    LaunchedEffect(playSeed) {
+        // 再生トリガーが変わるたびに新しいスクランブルを開始
+        val random = Random(playSeed)
+        repeat(ScrambleFrameCount) { frameIndex ->
+            val progress = frameIndex.toScrambleProgress(totalFrames = ScrambleFrameCount)
+            displayLines = targetLines.map { line ->
+                line.scrambledCopy(
+                    progress = progress,
+                    random = random,
+                )
+            }
+            delay(ScrambleFrameIntervalMillis)
+        }
+        // 最終フレームで確定したテキストを表示
+        displayLines = targetLines
+    }
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(20.dp))
+            .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.45f))
+            .padding(24.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            // ターゲットのメッセージをスクランブル表示
+            displayLines.forEach { line ->
+                Text(
+                    text = line,
+                    style = MaterialTheme.typography.bodyLarge.copy(fontFamily = FontFamily.Monospace),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+        Spacer(modifier = Modifier.height(4.dp))
+        Button(onClick = { playSeed++ }) {
+            Text(text = "Scramble Again")
+        }
+    }
+}
+
+// 表示フレーム数に対して進捗率を算出する拡張関数
+private fun Int.toScrambleProgress(totalFrames: Int): Float {
+    require(totalFrames > 1)
+    return (this.toFloat() / (totalFrames - 1)).coerceIn(0f, 1f)
+}
+
+// スクランブル用のテキストを生成する拡張関数
+private fun String.scrambledCopy(
+    progress: Float,
+    random: Random,
+): String {
+    if (isEmpty() || progress >= 1f) return this
+    val revealCount = (length * progress).toInt().coerceIn(0, length)
+    val builder = StringBuilder(length)
+    forEachIndexed { index, character ->
+        val resolved = when {
+            index < revealCount -> character
+            character.isScrambleStable() -> character
+            else -> ScrambleGlyphs.random(random)
+        }
+        builder.append(resolved)
+    }
+    return builder.toString()
+}
+
+// スクランブル中でも変化させない文字かどうかを判定する拡張関数
+private fun Char.isScrambleStable(): Boolean {
+    return isWhitespace() || !isLetterOrDigit()
+}
+
+private val ScrambleGlyphs: List<Char> = buildList {
+    addAll('A'..'Z')
+    addAll('a'..'z')
+    addAll('0'..'9')
+    addAll(listOf('-', '+', '*', '#', '%', '=', '@'))
+}
+
+private const val ScrambleFrameCount: Int = 28
+private const val ScrambleFrameIntervalMillis: Long = 40L
+
+@Preview
+@Composable
+private fun ScrambleTextItemPreview() {
+    UiGallary01Theme {
+        Surface(color = MaterialTheme.colorScheme.background) {
+            ScrambleTextItem(
+                modifier = Modifier.padding(24.dp)
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/uigallary01/ScrambleTextItem.kt
+++ b/app/src/main/java/com/example/uigallary01/ScrambleTextItem.kt
@@ -29,7 +29,7 @@ fun ScrambleTextItem(
     modifier: Modifier = Modifier,
 ) {
     // ギャラリー表示用の文面を定義
-    val targetLines = ScrambleDemoLines
+    val targetText = ScrambleDemoText
     var playSeed by rememberSaveable { mutableIntStateOf(0) }
 
     Column(
@@ -42,15 +42,14 @@ fun ScrambleTextItem(
     ) {
         Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
             // 再生シードをキーにスクランブル表示を更新
-            targetLines.forEachIndexed { index, line ->
-                ScrambleText(
-                    text = line,
-                    playKey = playSeed to index,
-                    scrambleSeed = playSeed * 31 + index,
-                    style = MaterialTheme.typography.bodyLarge.copy(fontFamily = FontFamily.Monospace),
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
+            ScrambleText(
+                text = targetText,
+                playKey = playSeed,
+                scrambleSeed = playSeed,
+                lineAnimationMode = ScrambleLineAnimationMode.Individually,
+                style = MaterialTheme.typography.bodyLarge.copy(fontFamily = FontFamily.Monospace),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
         Spacer(modifier = Modifier.height(4.dp))
         Button(onClick = { playSeed++ }) {
@@ -64,6 +63,8 @@ private val ScrambleDemoLines = listOf(
     "Fragments align into a message.",
     "Embrace the moment decoding you.",
 )
+
+private val ScrambleDemoText = ScrambleDemoLines.joinToString(separator = "\n")
 
 @Preview
 @Composable


### PR DESCRIPTION
## Summary
- add a scramble text gallery card that animates random glyphs into the final message
- register the scramble text showcase within the gallery list

## Testing
- ./gradlew --console=plain assembleDebug

------
https://chatgpt.com/codex/tasks/task_e_68dde19d4718832f9382c3e09d34aa36