### PR TITLE
Ensure expanded gallery items remain visible

### DIFF
--- a/app/src/main/java/com/example/uigallary01/DigitalRainBackgroundItem.kt
+++ b/app/src/main/java/com/example/uigallary01/DigitalRainBackgroundItem.kt
@@ -52,6 +52,7 @@ fun DigitalRainBackgroundItem(
         modifier = modifier
             .fillMaxWidth()
             .height(animatedHeight)
+            .ensureVisibleOnExpand(isExpanded)
             .clip(RoundedCornerShape(24.dp))
             .clipToBounds()
             .background(Color.Black)

--- a/app/src/main/java/com/example/uigallary01/ModifierExtensions.kt
+++ b/app/src/main/java/com/example/uigallary01/ModifierExtensions.kt
@@ -1,0 +1,25 @@
+package com.example.uigallary01
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.relocation.BringIntoViewRequester
+import androidx.compose.foundation.relocation.bringIntoViewRequester
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+
+// 展開時に対象要素が必ず画面内に収まるようスクロールを依頼する拡張関数
+@OptIn(ExperimentalFoundationApi::class)
+fun Modifier.ensureVisibleOnExpand(isExpanded: Boolean): Modifier = composed {
+    val bringIntoViewRequester = remember { BringIntoViewRequester() }
+
+    LaunchedEffect(isExpanded) {
+        if (isExpanded) {
+            withFrameNanos { }
+            bringIntoViewRequester.bringIntoView()
+        }
+    }
+
+    bringIntoViewRequester(bringIntoViewRequester)
+}

--- a/app/src/main/java/com/example/uigallary01/MoodySnowBackgroundItem.kt
+++ b/app/src/main/java/com/example/uigallary01/MoodySnowBackgroundItem.kt
@@ -61,6 +61,7 @@ fun MoodySnowBackgroundItem(
         modifier = modifier
             .fillMaxWidth()
             .height(animatedHeight)
+            .ensureVisibleOnExpand(isExpanded)
             .clip(RoundedCornerShape(24.dp))
             .clickable { isExpanded = !isExpanded },
         state = state,


### PR DESCRIPTION
## Summary
- add a reusable modifier extension that requests scrolling the item fully into view when expanded
- apply the new extension to the Digital Rain and Moody Snow gallery items so they stay visible after tapping to expand

## Testing
- ./gradlew --console=plain assembleDebug

------
https://chatgpt.com/codex/tasks/task_e_68dded1c1620832fb8fde8372d40d4ed