### PR TITLE
Add workflow to build and share APK on PRs

### DIFF
--- a/.github/workflows/pr-build-apk.yml
+++ b/.github/workflows/pr-build-apk.yml
@@ -1,0 +1,78 @@
+name: Build Debug APK
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+  workflow_dispatch:
+
+concurrency:
+  group: pr-build-apk-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  assemble:
+    name: Assemble Debug APK
+    runs-on: ubuntu-latest
+    env:
+      ARTIFACT_NAME: pr-debug-apk-${{ github.run_id }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v1
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Android SDK をセットアップ
+        uses: android-actions/setup-android@v3
+        with:
+          api-level: 34
+          build-tools: 34.0.0
+
+      - name: Make gradlew executable
+        run: chmod +x gradlew
+
+      - name: Build debug APK
+        run: ./gradlew --console=plain assembleDebug
+
+      - name: Upload debug APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.ARTIFACT_NAME }}
+          path: '**/build/outputs/apk/debug/*.apk'
+          if-no-files-found: error
+
+      - name: Prepare run URL
+        run: echo "RUN_URL=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> "$GITHUB_ENV"
+
+      - name: Share artifact link on PR
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-identifier: apk-artifact-link
+          body: |
+            <!-- apk-artifact-link -->
+            📱 Debug APK アーティファクト **${{ env.ARTIFACT_NAME }}** をアップロードしました。
+            Actions の実行ページからダウンロードできます: [Run Artifacts](${{ env.RUN_URL }}#artifacts)
+
+      - name: Note for forked PR
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        run: echo "Forked PR のためコメント投稿をスキップしました。Artifacts ページはこちら: ${{ env.RUN_URL }}"

--- a/.github/workflows/pr-build-apk.yml
+++ b/.github/workflows/pr-build-apk.yml
@@ -20,8 +20,11 @@ jobs:
   assemble:
     name: Assemble Debug APK
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       ARTIFACT_NAME: pr-debug-apk-${{ github.run_id }}
+      ORG_GRADLE_PROJECT_org.gradle.jvmargs: -Xmx2g -Dfile.encoding=UTF-8
+      GRADLE_OPTS: -Dorg.gradle.daemon=false
 
     steps:
       - name: Checkout
@@ -57,6 +60,7 @@ jobs:
           name: ${{ env.ARTIFACT_NAME }}
           path: '**/build/outputs/apk/debug/*.apk'
           if-no-files-found: error
+          retention-days: 14
 
       - name: Prepare run URL
         run: echo "RUN_URL=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> "$GITHUB_ENV"
@@ -71,7 +75,9 @@ jobs:
           body: |
             <!-- apk-artifact-link -->
             📱 Debug APK アーティファクト **${{ env.ARTIFACT_NAME }}** をアップロードしました。
+            Run: ${{ github.run_id }} / Artifact: ${{ env.ARTIFACT_NAME }}
             Actions の実行ページからダウンロードできます: [Run Artifacts](${{ env.RUN_URL }}#artifacts)
+            直接URLはこちらです: ${{ env.RUN_URL }}
 
       - name: Note for forked PR
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository


### PR DESCRIPTION
## Summary
- build the debug APK for pull requests and manual runs, uploading a run-scoped artifact
- share the Actions run artifacts link on same-repo pull requests and skip commenting for forks
- harden the workflow with concurrency cancellation, explicit permissions, and Gradle tooling setup

## Testing
- ./gradlew --console=plain assembleDebug

------
https://chatgpt.com/codex/tasks/task_e_68df32d4ff38832fac360cded9ebcf1d