### PR TITLE
Fix forked PR note step quoting

### DIFF
--- a/.github/workflows/pr-build-apk.yml
+++ b/.github/workflows/pr-build-apk.yml
@@ -47,9 +47,7 @@ jobs:
       - name: Android SDK をセットアップ
         uses: android-actions/setup-android@v3
         with:
-          packages: |
-            platforms;android-34
-            build-tools;34.0.0
+          packages: tools platform-tools platforms;android-34 build-tools;34.0.0
 
       - name: Make gradlew executable
         run: chmod +x gradlew

--- a/.github/workflows/pr-build-apk.yml
+++ b/.github/workflows/pr-build-apk.yml
@@ -41,12 +41,15 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v3
+        with:
+          cache-disabled: true
 
       - name: Android SDK をセットアップ
         uses: android-actions/setup-android@v3
         with:
-          api-level: 34
-          build-tools: 34.0.0
+          packages: |
+            platforms;android-34
+            build-tools;34.0.0
 
       - name: Make gradlew executable
         run: chmod +x gradlew
@@ -67,7 +70,7 @@ jobs:
 
       - name: Share artifact link on PR
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/pr-build-apk.yml
+++ b/.github/workflows/pr-build-apk.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          cache-read-only: true
+          cache-read-only: ${{ github.event_name == 'pull_request' || github.ref != 'refs/heads/main' }}
 
       - name: Android SDK をセットアップ
         uses: android-actions/setup-android@v3

--- a/.github/workflows/pr-build-apk.yml
+++ b/.github/workflows/pr-build-apk.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Share artifact link on PR
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-        uses: peter-evans/create-or-update-comment@v3
+        uses: peter-evans/create-or-update-comment@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/pr-build-apk.yml
+++ b/.github/workflows/pr-build-apk.yml
@@ -66,19 +66,41 @@ jobs:
       - name: Prepare run URL
         run: echo "RUN_URL=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> "$GITHUB_ENV"
 
-      - name: Share artifact link on PR
+      - name: Find existing artifact comment
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-        uses: peter-evans/create-or-update-comment@v4
+        id: find-artifact-comment
+        uses: peter-evans/find-comment@v3
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '<!-- apk-artifact-link -->'
+
+      - name: Share artifact link on PR
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && steps.find-artifact-comment.outputs.comment-id == ''
+        uses: peter-evans/create-or-update-comment@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
-          comment-identifier: apk-artifact-link
           body: |
             <!-- apk-artifact-link -->
             📱 Debug APK アーティファクト **${{ env.ARTIFACT_NAME }}** をアップロードしました。
             Run: ${{ github.run_id }} / Artifact: ${{ env.ARTIFACT_NAME }}
             Actions の実行ページからダウンロードできます: [Run Artifacts](${{ env.RUN_URL }}#artifacts)
             直接URLはこちらです: ${{ env.RUN_URL }}
+
+      - name: Update artifact link on PR
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && steps.find-artifact-comment.outputs.comment-id != ''
+        uses: peter-evans/create-or-update-comment@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          comment-id: ${{ steps.find-artifact-comment.outputs.comment-id }}
+          body: |
+            <!-- apk-artifact-link -->
+            📱 Debug APK アーティファクト **${{ env.ARTIFACT_NAME }}** をアップロードしました。
+            Run: ${{ github.run_id }} / Artifact: ${{ env.ARTIFACT_NAME }}
+            Actions の実行ページからダウンロードできます: [Run Artifacts](${{ env.RUN_URL }}#artifacts)
+            直接URLはこちらです: ${{ env.RUN_URL }}
+          edit-mode: replace
 
       - name: Note for forked PR
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository

--- a/.github/workflows/pr-build-apk.yml
+++ b/.github/workflows/pr-build-apk.yml
@@ -40,9 +40,9 @@ jobs:
           java-version: 17
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v4
         with:
-          cache-disabled: true
+          cache-read-only: true
 
       - name: Android SDK をセットアップ
         uses: android-actions/setup-android@v3

--- a/.github/workflows/pr-build-apk.yml
+++ b/.github/workflows/pr-build-apk.yml
@@ -81,4 +81,5 @@ jobs:
 
       - name: Note for forked PR
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
-        run: echo "Forked PR のためコメント投稿をスキップしました。Artifacts ページはこちら: ${{ env.RUN_URL }}"
+        run: |
+          echo "Forked PR のためコメント投稿をスキップしました。Artifacts ページはこちら: $RUN_URL"


### PR DESCRIPTION
## Summary
- wrap the forked PR note step run command in a multiline block to avoid YAML parsing issues and use the exported RUN_URL variable directly

## Testing
- ./gradlew --console=plain assembleDebug

------
https://chatgpt.com/codex/tasks/task_e_68df3dd5f6b8832f8eb5d7eb6af62fbb